### PR TITLE
Eliminate secret scanner file race

### DIFF
--- a/scripts/audit-secrets.mjs
+++ b/scripts/audit-secrets.mjs
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { readdir, readFile, stat } from 'node:fs/promises';
+import { open, readdir, stat } from 'node:fs/promises';
 import { basename, extname, join, relative } from 'node:path';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
@@ -24,16 +24,21 @@ function lineNumber(source, index) {
 }
 
 async function scanFile(path, displayName) {
-  const metadata = await stat(path);
-  if (!metadata.isFile() || metadata.size > MAX_TEXT_BYTES) return;
-  const buffer = await readFile(path);
-  if (buffer.includes(0)) return;
-  const source = buffer.toString('utf8');
-  for (const [rule, pattern] of rules) {
-    pattern.lastIndex = 0;
-    for (const match of source.matchAll(pattern)) {
-      findings.push(`${displayName}:${lineNumber(source, match.index)} (${rule})`);
+  const handle = await open(path, 'r');
+  try {
+    const metadata = await handle.stat();
+    if (!metadata.isFile() || metadata.size > MAX_TEXT_BYTES) return;
+    const buffer = await handle.readFile();
+    if (buffer.length > MAX_TEXT_BYTES || buffer.includes(0)) return;
+    const source = buffer.toString('utf8');
+    for (const [rule, pattern] of rules) {
+      pattern.lastIndex = 0;
+      for (const match of source.matchAll(pattern)) {
+        findings.push(`${displayName}:${lineNumber(source, match.index)} (${rule})`);
+      }
     }
+  } finally {
+    await handle.close();
   }
 }
 


### PR DESCRIPTION
## Changement

- ouvre chaque fichier une seule fois avant de contrôler ses métadonnées et de le lire
- utilise le même descripteur pour supprimer la fenêtre TOCTOU signalée par CodeQL (`js/file-system-race`, alerte #27)
- conserve la limite de 5 Mio et la vérifie aussi après lecture
- ferme le descripteur dans un bloc `finally`

## Cause

Le scanner appelait `stat(path)` puis `readFile(path)`. Le fichier ciblé pouvait être remplacé entre ces deux opérations.

## Validation

- `npm run test:secrets`
- `npm run test:security`
- `npm run test:ci-policy`
- `npm run check` (0 erreur, 2 suggestions existantes)
